### PR TITLE
Non backwardscompatible change 1.0.0 for ajax

### DIFF
--- a/Test/html/htmlAjaxInstructions.txt
+++ b/Test/html/htmlAjaxInstructions.txt
@@ -1,7 +1,7 @@
 /*
 	htmlAjaxInstructions.txt
 	
-	version			: 0.1.3
+	version			: 1.0.0
 	last updated	: 28.10.2017
 	name			: Markus Fjellheim
 	description		:
@@ -20,13 +20,8 @@ HTML ajax instructions:
 		<script src="static/js/nm_callbacks.js"></script>
 		<script src="static/js/templater.js"></script>
 
-	To fill an element with html content:
-		<div data-fill="/getHTML?html=someContent"></div>
-	
-	
-	To replace and element with html content:
-		<div data-replace="/getHTML?html=someContent"></div>
-	
+	To fill an element with html content when the element is loaded:
+		<div data-load="/getHTML?html=someContent"></div>
 	
 	To make a button fill element with html content:
 		<button data-target="toBeFilled" data-fill="/getHTML?html=someContent">Button that will fill the h1</button>
@@ -35,7 +30,7 @@ HTML ajax instructions:
 		</h1>
 	
 	To make a button replace element with html content:
-		<button data-target="toBeReplaced" data-fill="/getHTML?html=someContent">Button that will replace the h1</button>
+		<button data-target="toBeReplaced" data-replace="/getHTML?html=someContent">Button that will replace the h1</button>
 		<h1 id="toBeReplaced">
 			Some h1 to be replaced
 		</h1>

--- a/Test/static/js/mf_ajax.js
+++ b/Test/static/js/mf_ajax.js
@@ -1,7 +1,7 @@
 /*
 	mf_ajax.js
 	
-	version			: 0.3.0
+	version			: 1.0.0
 	last updated	: 28.10.2017
 	name			: Markus Fjellheim
 	description		:
@@ -46,7 +46,6 @@ mf_AjaxHandler.prototype.checkButton = function(button){
 				"the response from the server.");
 			return -1;
 		}
-		//var 
 		button.addEventListener("click", function(e){
 			e.preventDefault();
 			var form = document.getElementById(button.dataset.formid);
@@ -98,7 +97,7 @@ mf_AjaxHandler.prototype.checkButton = function(button){
 			}else if(button.dataset.addlastchild != null){
 				this.addLastChild(targetId, button.dataset.addlastchild);
 			}else{
-				Tool.printError("Markus 1 did something wrong, ask him to fix it.");
+				Tool.printError("Markus F did something wrong, ask him to fix it.");
 			}
 		}
 	}
@@ -125,12 +124,21 @@ mf_AjaxHandler.prototype.searchElement = function(element){
 	}
 }
 mf_AjaxHandler.prototype.findAjaxData = function(element){
+	// not backwards compatability warning
+	if(!element.dataset.target && (element.dataset.fill || element.dataset.replace)){
+		Tool.printError("Element with id \"" + element.id + "\" has a data-fill attribute but no target. " +
+			"This is not supported as of version 1.0.0. If you want to load data on load, try \"data-load\" instad. " +
+			"See \"html/htmlAjaxInstructions.txt\" for more info."
+		);
+		return false;
+	}
+	//
 	if(element.tagName == "SCRIPT" && element.dataset.run == ""){
 		var code = element.innerHTML;
 		mf_AjaxHandler.evaluateScriptQue.push(code);
 		return false;
 	}
-	if(element.dataset.timeline == "" || !element.dataset.target && (element.dataset.fill || element.dataset.replace)){
+	if(element.dataset.timeline == "" || !element.dataset.target && element.dataset.load){
 		if(element.dataset.timeline == ""){ // load "mf_timeline.js"
 			var index = mf_addTimeline(element);
 			if(element.dataset.position || element.dataset.zoom){
@@ -147,10 +155,11 @@ mf_AjaxHandler.prototype.findAjaxData = function(element){
 				mf_timeline.timelines[index].zoom = zoom;
 			}
 		}else{ // load in other content
-			if(element.dataset.fill){
-				this.fillElementArgElement(element, element.dataset.fill);
-			}else{ // element.dataset.replace
-				this.replaceElementArgElement(element, element.dataset.replace);
+			if(element.dataset.load){
+				this.fillElementArgElement(element, element.dataset.load);
+			}else{
+				Tool.printError("Markus F did something wrong, ask him to fix it.");
+				return false;
 			}
 		}
 		return true;


### PR DESCRIPTION
-data attribute for filling element changed name to data-load="someHTML"
-data attribute for replacing element not supported any longer
-fixed error in htmlAjaxInstrucions